### PR TITLE
Fix CI pipeline: Key Vault npm auth and deprecated task warnings

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,18 +45,22 @@ jobs:
   steps:
     - template: pipeline-templates/build-steps.yml
 
-    - task: Npm@1
+    - task: AzureKeyVault@2
       inputs:
-        command: 'publish'
-        publishEndpoint: 'safeguard.js service connection'
+        azureSubscription: 'SafeguardOpenSource'
+        KeyVaultName: 'SafeguardBuildSecrets'
+        SecretsFilter: 'NpmOrgApiKey'
+      displayName: 'Get npm API key from Azure Key Vault'
+
+    - script: |
+        npm config set //registry.npmjs.org/:_authToken=$(NpmOrgApiKey)
+        npm publish
       condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
       displayName: 'Publish to npm (release)'
 
-    - task: Npm@1
-      inputs:
-        command: 'custom'
-        customCommand: 'publish --tag pre'
-        publishEndpoint: 'safeguard.js service connection'
+    - script: |
+        npm config set //registry.npmjs.org/:_authToken=$(NpmOrgApiKey)
+        npm publish --tag pre
       condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
       displayName: 'Publish to npm (pre-release)'
 

--- a/pipeline-templates/build-steps.yml
+++ b/pipeline-templates/build-steps.yml
@@ -1,7 +1,7 @@
 steps:
-  - task: NodeTool@0
+  - task: UseNode@1
     inputs:
-      versionSpec: '22.x'
+      version: '22.x'
     displayName: 'Install Node.js 22 LTS'
 
   - script: npm ci
@@ -44,7 +44,7 @@ steps:
         LICENSE
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
-  - task: PublishPipelineArtifact@0
+  - task: PublishPipelineArtifact@1
     displayName: 'Publish artifact'
     inputs:
       artifactName: 'drop'


### PR DESCRIPTION
- Replace Npm@1 task + safeguard.js service connection with AzureKeyVault@2 pulling NpmOrgApiKey from SafeguardBuildSecrets (consistent with SafeguardDotNet and safeguard-ps)
- Replace deprecated NodeTool@0 with UseNode@1
- Replace deprecated PublishPipelineArtifact@0 with v1