### PR TITLE
Skills harmonization: add a2a-workflow skill

### DIFF
--- a/.agents/skills/a2a-workflow/SKILL.md
+++ b/.agents/skills/a2a-workflow/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: a2a-workflow
+description: Use when wiring certificate-based A2A retrieval, brokering, or related Safeguard event listeners in Node.js.
+---
+
+# A2A Workflow
+
+## What A2A is
+
+Application-to-Application (A2A) in safeguard.js is the certificate-authenticated, Node-only path for non-interactive secret retrieval and brokering. The main entry point exports `A2AClient` from `src/a2a/index.ts`; the browser entry (`src/browser.ts`) does not. Internally, the client calls Safeguard A2A endpoints under `https://{host}/service/a2a/v4/...`, sends `Authorization: A2A ${apiKey}` for credential and broker calls, and returns secrets as `SecretValue` so callers must opt in to raw material with `.expose()`.
+
+## SDK surface
+
+Relevant implementation files are `src/a2a/index.ts`, `src/a2a/types.ts`, `src/auth/certificate.ts`, `src/http/node.ts`, and `samples/node/a2a-password.ts`. Across those files, `A2AClient` supports password retrieval, SSH key retrieval, API key secret retrieval, account discovery, password write-back, private-key write-back, and brokered access requests.
+
+This SDK does **not** provision A2A registrations or generate API keys. Appliance setup happens first; the SDK starts once you already have a registered certificate and at least one account API key.
+
+## Setup flow
+
+### 1. Register the client certificate in Safeguard
+
+On the appliance, create or update the A2A registration that trusts the client certificate your process will present over mTLS. That registration is what authorizes `GET /service/a2a/v4/A2ARegistrations` and the credential endpoints.
+
+### 2. Create the per-account API key
+
+For each retrievable account, generate the A2A API key in Safeguard. In SDK terms that key becomes the `apiKey` parameter passed to `retrievePassword`, `retrievePrivateKey`, `retrieveApiKeySecret`, `setPassword`, `setPrivateKey`, and `brokerAccessRequest`.
+
+### 3. Build the Node-side objects
+
+Use the root package entry, not `@oneidentity/safeguard/browser`:
+
+```typescript
+import { readFileSync } from 'node:fs';
+import {
+  A2AClient,
+  CertificateAuth,
+  NodeHttpClient,
+} from '@oneidentity/safeguard';
+
+const host = 'safeguard.sample.corp';
+const cert = readFileSync('ssl/a2a-cert.pem', 'utf8');
+const key = readFileSync('ssl/a2a-cert.key', 'utf8');
+const ca = readFileSync('ssl/ca.pem', 'utf8');
+
+const auth = new CertificateAuth({
+  cert,
+  key,
+  passphrase: process.env.SPP_KEY_PASSPHRASE,
+});
+
+const a2a = new A2AClient(host, {
+  auth,
+  ca,
+  verify: true,
+});
+
+const httpClient = new NodeHttpClient({
+  ...auth.getTlsOptions(),
+  ca: a2a.ca,
+  rejectUnauthorized: a2a.verify,
+});
+
+a2a.setHttpClient(httpClient);
+```
+
+### 4. Keep `verify` enabled unless you are in a lab
+
+`A2AClientOptions.verify` defaults to `true`. The Node HTTP layer expects `rejectUnauthorized`, so the common pattern is:
+
+```typescript
+const httpClient = new NodeHttpClient({
+  ...auth.getTlsOptions(),
+  rejectUnauthorized: a2a.verify,
+});
+```
+
+Only use `verify: false` for development against self-signed appliances.
+
+### 5. Understand the file-content boundary
+
+`CertificateAuth` accepts `cert`, `key`, `pfx`, `certFile`, `keyFile`, and `pfxFile` options, but `A2AClient` itself does not load files and does not auto-create a `NodeHttpClient`. In practice, the safest A2A pattern is to load PEM content yourself, construct `CertificateAuth`, then inject a preconfigured `NodeHttpClient` with `setHttpClient()` before making any A2A call.
+
+## Credential retrieval
+
+### Discover what the certificate can access
+
+`getRetrievableAccounts()` issues `GET https://{host}/service/a2a/v4/A2ARegistrations` and returns `RetrievableAccount[]`:
+
+```typescript
+const accounts = await a2a.getRetrievableAccounts();
+for (const account of accounts) {
+  console.log(account.AssetName, account.AccountName, account.ApiKey);
+}
+```
+
+Important fields from `src/a2a/types.ts`:
+
+- `AccountId`
+- `AssetId`
+- `AssetName`
+- `AccountName`
+- `DomainName`
+- `AccountType`
+- `ApiKey`
+
+Use discovery when you want the appliance to tell you which API keys are valid for the presented certificate.
+
+### Retrieve a password
+
+```typescript
+const password = await a2a.retrievePassword(apiKey);
+const rawPassword = password.expose();
+```
+
+Implementation detail: `retrievePassword()` calls `#a2aRequest(apiKey, 'Credentials', 'Password')` and wraps the response body in `SecretValue`.
+
+### Retrieve an SSH private key
+
+```typescript
+import { SshKeyFormat } from '@oneidentity/safeguard';
+
+const sshKey = await a2a.retrievePrivateKey(apiKey, SshKeyFormat.OpenSsh);
+const rawKey = sshKey.expose();
+```
+
+Available formats from `SshKeyFormat`:
+
+- `OpenSsh`
+- `Ssh2`
+- `Putty`
+
+Internally the SDK requests `GET /service/a2a/v4/Credentials/SshKey?keyFormat=${format}`.
+
+### Retrieve an API key secret
+
+```typescript
+const apiSecret = await a2a.retrieveApiKeySecret(apiKey);
+const rawSecret = apiSecret.expose();
+```
+
+This maps to `GET /service/a2a/v4/Credentials/ApiKey`.
+
+### Write credentials back
+
+Use these only when the appliance registration is allowed to update the managed account:
+
+```typescript
+await a2a.setPassword(apiKey, 'NewPassword123!');
+
+await a2a.setPrivateKey(
+  apiKey,
+  privateKeyPem,
+  optionalPassphrase,
+  SshKeyFormat.OpenSsh,
+);
+```
+
+`setPrivateKey()` sends a JSON payload with `PrivateKey`, `KeyFormat`, and optional `Passphrase` to `PUT /service/a2a/v4/Credentials/SshKey`.
+
+## Brokering
+
+A2A brokering is supported through `brokerAccessRequest(apiKey, request)`, which posts to `POST /service/a2a/v4/AccessRequests` and accepts HTTP `200` or `201`.
+
+Relevant enums and types live in `src/a2a/types.ts`:
+
+- `BrokeredAccessRequestType.Password`
+- `BrokeredAccessRequestType.SshKey`
+- `BrokeredAccessRequestType.ApiKey`
+- `BrokeredAccessRequestType.Token`
+- `BrokeredAccessRequestType.RdpFile`
+- `BrokeredAccessRequestType.RemoteDesktop`
+- `BrokeredAccessRequestType.SshSession`
+
+Example:
+
+```typescript
+import {
+  BrokeredAccessRequestType,
+  type BrokeredAccessResponse,
+} from '@oneidentity/safeguard';
+
+const response: BrokeredAccessResponse = await a2a.brokerAccessRequest(apiKey, {
+  AccessType: BrokeredAccessRequestType.Password,
+  AssetId: 123,
+  AccountId: 456,
+  ForUserName: 'svc-automation',
+});
+
+console.log(response.RequestId);
+if (response.AccessToken) {
+  console.log('Broker token acquired');
+}
+```
+
+The response is parsed JSON and always includes `RequestId`; `AccessToken` is optional.
+
+## Event listeners / SignalR
+
+There is no A2A-specific SignalR wrapper in this repo. Real-time events are a separate feature exposed from `@oneidentity/safeguard/events`:
+
+- `SafeguardEventListener` in `src/events/listener.ts`
+- `PersistentSafeguardEventListener` in `src/events/persistent.ts`
+
+Both subscribe to the Safeguard hub method `NotifyEventAsync` on `https://{host}/service/event/signalr`.
+
+Use this pattern when an automation process needs both A2A secret retrieval **and** general Safeguard event monitoring:
+
+1. Use `A2AClient` for A2A retrieval or brokering.
+2. Separately authenticate for a Safeguard access token using `PasswordAuth`, `TokenAuth`, or a certificate-based Safeguard login flow.
+3. Build a SignalR `HubConnection` with `accessTokenFactory`.
+4. Wrap the connection in `SafeguardEventListener` or `PersistentSafeguardEventListener`.
+
+Minimal example:
+
+```typescript
+import { PasswordAuth, NodeHttpClient, MemoryStorage } from '@oneidentity/safeguard';
+import { SafeguardEventListener } from '@oneidentity/safeguard/events';
+import * as signalR from '@microsoft/signalr';
+
+const auth = new PasswordAuth({ username, password, provider: 'Local' });
+const httpClient = new NodeHttpClient();
+const storage = new MemoryStorage();
+const tokenSet = await auth.authenticate(host, httpClient, storage);
+
+const connection = new signalR.HubConnectionBuilder()
+  .withUrl(`https://${host}/service/event/signalr`, {
+    accessTokenFactory: () => tokenSet.accessToken.expose(),
+  })
+  .withAutomaticReconnect()
+  .build();
+
+const listener = new SafeguardEventListener(connection);
+listener.on('NotifyEventAsync', (event) => console.log(event.EventName));
+await listener.start();
+```
+
+If you need reconnect behavior plus token refresh, use `PersistentSafeguardEventListener`. It tracks listener state (`starting`, `connected`, `disconnected`, `reconnecting`, `stopped`) and refreshes tokens when they are expired or within the built-in 60-second margin.
+
+## Error scenarios and troubleshooting
+
+### `ConfigurationError: A2AClient requires a host`
+
+You passed an empty host to the constructor. The class validates this immediately in `src/a2a/index.ts`.
+
+### `ConfigurationError: A2AClient requires a CertificateAuth`
+
+A2A in this SDK is certificate-only. Password auth and token auth are not accepted by `A2AClientOptions.auth`.
+
+### `ConfigurationError: HttpClient not set`
+
+Every A2A call eventually reaches `#ensureHttpClient()`. Call `a2a.setHttpClient(...)` before `retrievePassword()`, `getRetrievableAccounts()`, or any other A2A method.
+
+### TLS handshake or certificate problems
+
+Typical causes:
+
+- client cert/key do not match the registered Safeguard certificate
+- custom CA bundle is missing
+- `rejectUnauthorized` is still `true` against a self-signed lab appliance
+- the process loaded file paths but never loaded the PEM contents it intended to send
+
+Start by validating the `NodeHttpClient` TLS options and the appliance-side certificate registration.
+
+### `ApiError` on retrieve, write-back, or brokering
+
+`A2AClient` converts non-success HTTP responses with `ApiError.fromResponse(...)`:
+
+- retrieval/discovery expect `200`
+- `setPassword()` and `setPrivateKey()` accept `200` or `204`
+- `brokerAccessRequest()` accepts `200` or `201`
+
+Treat these like appliance or authorization failures and inspect the JSON body for the server message.
+
+### Secret shows up as `[redacted]`
+
+That is expected. `retrievePassword()`, `retrievePrivateKey()`, and `retrieveApiKeySecret()` return `SecretValue`, which redacts `toString()` and `toJSON()`. Call `.expose()` only at the point where you truly need the raw secret.
+
+### Browser import failures
+
+A2A is not exported from `src/browser.ts`. Use the root package entry in Node.js. If you also need events, install the optional peer dependency first:
+
+```bash
+npm install @microsoft/signalr
+```
+
+### Long-running processes
+
+Dispose shared HTTP clients when you shut the process down:
+
+```typescript
+httpClient.dispose?.();
+```
+
+This matches the cleanup pattern used in `samples/node/signalr-events.ts` and `samples/node/persistent-events.ts`.

--- a/.agents/skills/api-patterns/SKILL.md
+++ b/.agents/skills/api-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-patterns
-description: Service enum, URL construction, auth strategies, error handling, SDK usage patterns
+description: Use when making Safeguard API calls, wiring auth strategies, or following SDK request and response patterns.
 trigger: Making Safeguard API calls, SDK usage, understanding request/response patterns
 ---
 

--- a/.agents/skills/architecture/SKILL.md
+++ b/.agents/skills/architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architecture
-description: Module architecture, conditional exports, platform detection, auth strategy internals, HTTP layer
+description: Use when changing module structure, auth internals, conditional exports, or the HTTP and storage layers.
 trigger: Working on internals, auth strategies, HTTP layer, module structure, platform-specific code
 ---
 

--- a/.agents/skills/build-and-release/SKILL.md
+++ b/.agents/skills/build-and-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build-and-release
-description: tsdown configuration, ADO pipeline-templates, npm publish workflow, version derivation
+description: Use when changing tsdown config, Azure Pipelines, publishing flow, or version derivation.
 trigger: Pipeline changes, publishing, versioning, build issues, tsdown config, npm pack
 ---
 

--- a/.agents/skills/testing-guide/SKILL.md
+++ b/.agents/skills/testing-guide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing-guide
-description: Vitest configuration, environment variables, integration test patterns, fixtures, and appliance setup
+description: Use when working on Vitest configuration, appliance-backed tests, fixtures, or debugging test failures.
 trigger: Working on tests, test failures, appliance setup, debugging test output
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,83 +1,87 @@
 # AGENTS.md — @oneidentity/safeguard
 
-TypeScript SDK for the One Identity Safeguard Web API.
-Dual-target: Node.js (server automation, A2A, cert auth, SignalR) and Browser (PKCE login, sessionStorage, ESM bundle).
+TypeScript SDK for the One Identity Safeguard Web API. The repo targets Node.js (server automation, A2A, certificate auth, SignalR) and browsers (PKCE, session-backed auth, ESM bundle).
 
 ## Project Structure
 
-```
-src/
-├── index.ts              # Node barrel (all exports)
-├── browser.ts            # Browser barrel (no Node-only imports)
-├── client.ts             # SafeguardClient (main class)
-├── auth/                 # Auth strategy objects (password, cert, PKCE, token, anonymous)
-├── a2a/                  # A2AClient (retrieve, set, discover, broker)
-├── events/               # SafeguardEventListener + PersistentSafeguardEventListener
-│                         # Separate subpath: @oneidentity/safeguard/events (opt-in)
-├── http/                 # HttpClient abstraction (undici Node, native fetch browser)
-├── storage/              # StorageProvider (MemoryStorage, BrowserSessionStorage)
-├── errors.ts             # Error hierarchy (SafeguardError → ApiError → Auth/NotFound/etc)
-├── secret.ts             # SecretValue (masks toString/toJSON, .expose() for raw value)
-├── types.ts              # Service, HttpMethod, SafeguardResponse enums/interfaces
-└── utils.ts              # URL assembly, crypto helpers, host validation
-tests/
-├── unit/                 # Pure logic tests (no heavy mocking)
-└── integration/          # Live appliance tests (auto-skip when SPP_HOST unset)
-pipeline-templates/       # ADO pipeline YAML (build-steps, global-variables, versionnumber)
-scripts/                  # Post-build helpers (fix-dts.mjs)
-.agents/skills/           # Modular agent context
-samples/                  # Node + Browser TypeScript examples
-```
+- `src/index.ts` — Node entry point with A2A, cert auth, HTTP, and events exports
+- `src/browser.ts` — browser-safe entry point without Node-only modules
+- `src/client.ts` — `SafeguardClient`
+- `src/auth/` — auth strategies (`PasswordAuth`, `CertificateAuth`, PKCE, token, anonymous)
+- `src/a2a/` — `A2AClient`, broker types, SSH key formats
+- `src/events/` — `SafeguardEventListener` and `PersistentSafeguardEventListener`
+- `src/http/` — `NodeHttpClient` and `BrowserHttpClient`
+- `src/storage/` — memory and browser session storage providers
+- `tests/unit/` — pure logic tests
+- `tests/integration/` — live appliance tests
+- `samples/` — Node and browser usage examples
+- `pipeline-templates/` and `azure-pipelines.yml` — build/release automation
+- `.agents/skills/` — on-demand repo skills
 
-## Setup & Build
+## Setup and Build
 
 ```bash
-npm ci                    # Install deps (requires Node >=20, CI uses 22)
-npm run build             # tsdown → dist/ (ESM + CJS + .d.ts)
-npm run lint              # ESLint 9 + @typescript-eslint
-npm run typecheck         # tsc --noEmit (strict)
-npm run test              # Vitest unit tests
-npm run test:integration  # Vitest integration (requires SPP_HOST env var)
+npm ci
+npm run typecheck
+npm run build
 ```
+
+Use Node.js 20+ locally; CI runs on Node 22.
+
+## Linting
+
+```bash
+npm run lint
+npm run format:check
+```
+
+## Testing
+
+```bash
+npm run test
+npm run test:integration
+```
+
+Integration tests use a live appliance and expect `SPP_HOST` plus related `SPP_*` credentials.
 
 ## Code Conventions
 
-- **TypeScript strict mode** — no `any` without justification
-- **Auth as strategy objects** — pluggable, instance-based, no global state
-- **Async/await only** — no callbacks, all methods return Promises
-- **Error hierarchy** — throw typed errors (ApiError, TransportError, ConfigurationError)
-- **SecretValue for credentials** — never log raw secrets
-- **Instance-based clients** — multiple concurrent SafeguardClient instances supported
-- **Platform separation** — Node-only code stays in Node entry; browser barrel excludes fs/tls/undici
-- **No side effects at import** — constructors do no I/O
-
-## Versioning
-
-Do NOT manually edit `version` in package.json. CI stamps version from git tags:
-- Tag `v8.0.0` → publishes `8.0.0` to npm (latest)
-- Push to `main` → publishes `8.0.0-pre{buildId}` prerelease (npm tag: pre)
+- Keep TypeScript strict; avoid `any` unless justified
+- Treat auth as pluggable strategy objects with no global state
+- Use async/await and Promise-based APIs only
+- Throw typed SDK errors (`ApiError`, `TransportError`, `ConfigurationError`, etc.)
+- Wrap secrets in `SecretValue`; only call `.expose()` at the point of use
+- Preserve platform separation: Node-only code stays out of `src/browser.ts`
+- Avoid side effects at import time; constructors should not perform I/O
 
 ## CI/CD
 
-- **Azure Pipelines** — unified `azure-pipelines.yml` with `pipeline-templates/`
-- **Trigger:** PR to `main` → validation; merge to `main` → dev prerelease; tag `v*` → stable release
-- **npm publish:** via `AzureKeyVault@2` → `SafeguardBuildSecrets` → `NpmOrgApiKey` (90-day rotation)
-- **GitHub Release:** `PangaeaBuild-GitHub` connection
+For pipeline flow, version stamping, npm publish, and release details, load [build-and-release](.agents/skills/build-and-release/SKILL.md).
 
 ## Security
 
-- Never commit secrets, tokens, or credentials
-- Never set `verify: false` in production code or samples (tests may use it against lab appliances)
-- Use `SecretValue` for any credential field — call `.expose()` only when intentionally needed
-- All auth constructors and `SafeguardClient` validate `host` — reject URLs and path-traversal
-- Tokens live in-memory only (no sessionStorage persistence) — XSS-safe by default
-- `@microsoft/signalr` is an optional peer dependency to reduce supply chain exposure
+- Never commit secrets, tokens, certificates, or private keys
+- Keep TLS verification enabled in production; `verify: false` is lab-only
+- Prefer in-memory tokens and avoid browser persistence unless the caller explicitly accepts the XSS tradeoff
+- Validate host handling and optional peer dependencies when changing auth, HTTP, or SignalR code
 
-## Skill Routing
+## Versioning
 
-| Skill | When to Load |
-|-------|-------------|
-| [testing-guide](.agents/skills/testing-guide/SKILL.md) | Writing/debugging tests, appliance setup, test failures |
-| [api-patterns](.agents/skills/api-patterns/SKILL.md) | Making Safeguard API calls, SDK usage patterns |
-| [architecture](.agents/skills/architecture/SKILL.md) | Working on internals, auth strategies, HTTP layer, module structure |
-| [build-and-release](.agents/skills/build-and-release/SKILL.md) | Pipeline changes, publishing, versioning, tsdown config |
+Do not hand-edit `package.json` version. Release versioning is derived from git tags; `main` builds publish prereleases and `v*` tags publish stable packages.
+
+## On-demand skills
+
+| Skill | Use when |
+|-------|----------|
+| [a2a-workflow](.agents/skills/a2a-workflow/SKILL.md) | Wiring certificate-based A2A retrieval, brokering, or adjacent event-listener flows |
+| [testing-guide](.agents/skills/testing-guide/SKILL.md) | Writing or debugging unit/integration tests and appliance-backed test setup |
+| [api-patterns](.agents/skills/api-patterns/SKILL.md) | Making Safeguard API calls, choosing auth strategies, or following SDK usage patterns |
+| [architecture](.agents/skills/architecture/SKILL.md) | Changing module boundaries, HTTP/auth/storage internals, or platform-specific exports |
+| [build-and-release](.agents/skills/build-and-release/SKILL.md) | Working on pipelines, builds, publishing, or version derivation |
+
+## Keeping this file current
+
+- Keep this file short, broadly applicable, and always-on
+- Move detailed workflows into `.agents/skills/`
+- Update the skills table when adding, removing, or renaming a skill
+- Prefer one-line pointers here for deep CI/CD or operational detail


### PR DESCRIPTION
Implements the skills harmonization plan:

- Created `a2a-workflow` skill (A2AClient, credential retrieval, brokering, SignalR events)
- Updated AGENTS.md to standard template (security section, skill routing table)
- Normalized existing skill frontmatter

Part of cross-repo effort to standardize agent skills across all Safeguard SDK repositories.