### PR TITLE
Fix: Include API version in request URLs and fix A2A credential retrieval (8.0.1)

### DIFF
--- a/.agents/skills/api-patterns/SKILL.md
+++ b/.agents/skills/api-patterns/SKILL.md
@@ -71,11 +71,11 @@ client.setHttpClient(new NodeHttpClient({ rejectUnauthorized: false }));
 await client.connect();
 
 // Convenience verbs (typed)
-const users = await client.get<User[]>(Service.CORE, 'v4/Users');
-const user = await client.post<User>(Service.CORE, 'v4/Users', { json: body });
+const users = await client.get<User[]>(Service.CORE, 'Users');
+const user = await client.post<User>(Service.CORE, 'Users', { json: body });
 
 // Low-level invoke (full control)
-const response = await client.invoke(Service.CORE, HttpMethod.GET, 'v4/Me', {
+const response = await client.invoke(Service.CORE, HttpMethod.GET, 'Me', {
   fullResponse: true,
   signal: controller.signal,
 });
@@ -97,7 +97,7 @@ Pass them as a flat `Record<string, string | number | boolean>`:
 
 ```typescript
 // filter, fields, orderby, page, count — no $ prefix
-const users = await client.get<User[]>(Service.CORE, 'v4/Users', {
+const users = await client.get<User[]>(Service.CORE, 'Users', {
   query: { filter: 'Disabled eq false', fields: 'UserName,Name', orderby: 'UserName' }
 });
 ```
@@ -112,7 +112,7 @@ The SDK passes these verbatim as URL query params. It does NOT transform them.
 
 ```typescript
 try {
-  await client.get(Service.CORE, 'v4/Users/999999');
+  await client.get(Service.CORE, 'Users/999999');
 } catch (err) {
   if (err instanceof NotFoundError) { /* 404 */ }
   if (err instanceof AuthenticationError) { /* 401 — token expired? */ }

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -156,18 +156,19 @@ let parsed = JSON.parse(result);
 
 ```typescript
 // v8.0 — response is already parsed
-const users = await client.get(Service.CORE, 'v4/Users');
+// Pass relative paths only — the SDK prepends the API version automatically.
+const users = await client.get(Service.CORE, 'Users');
 
 // POST
-const newUser = await client.post(Service.CORE, 'v4/Users', {
+const newUser = await client.post(Service.CORE, 'Users', {
   json: { Name: 'myuser', PrimaryAuthenticationProvider: { Id: -1 } },
 });
 
 // PUT
-await client.put(Service.CORE, `v4/Users/${id}/Password`, { json: 'NewPass123' });
+await client.put(Service.CORE, `Users/${id}/Password`, { json: 'NewPass123' });
 
 // DELETE
-await client.delete(Service.CORE, `v4/Users/${id}`);
+await client.delete(Service.CORE, `Users/${id}`);
 ```
 
 ### Service Enum
@@ -197,7 +198,7 @@ let result = await connection.invoke(SafeguardJs.Services.CORE, SafeguardJs.Http
 
 ```typescript
 // v8.0 — structured query object
-const users = await client.get(Service.CORE, 'v4/Users', {
+const users = await client.get(Service.CORE, 'Users', {
   query: { filter: "Name eq 'Admin'", fields: 'Id,Name' },
 });
 ```
@@ -319,7 +320,7 @@ try {
 import { ApiError, AuthenticationError, NotFoundError } from '@oneidentity/safeguard';
 
 try {
-  await client.get(Service.CORE, 'v4/Users/999999');
+  await client.get(Service.CORE, 'Users/999999');
 } catch (e) {
   if (e instanceof NotFoundError) {
     console.log('User not found');

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ const client = new SafeguardClient('safeguard.sample.corp', {
 
 await client.connect();
 
-const me = await client.get(Service.CORE, 'v4/Me');
+const me = await client.get(Service.CORE, 'Me');
 console.log(me);
 
 await client.disconnect();
@@ -97,7 +97,7 @@ const client = new SafeguardClient('safeguard.sample.corp', {
 
 await client.connect(); // Redirects to Safeguard login if no stored tokens
 
-const me = await client.get(Service.CORE, 'v4/Me');
+const me = await client.get(Service.CORE, 'Me');
 console.log(me);
 ```
 
@@ -117,7 +117,7 @@ const client = new SafeguardClient('safeguard.sample.corp', {
 });
 
 await client.connect();
-const me = await client.get(Service.CORE, 'v4/Me');
+const me = await client.get(Service.CORE, 'Me');
 await client.disconnect();
 ```
 
@@ -135,7 +135,7 @@ const client = new SafeguardClient('safeguard.sample.corp', {
 });
 
 await client.connect();
-const me = await client.get(Service.CORE, 'v4/Me');
+const me = await client.get(Service.CORE, 'Me');
 await client.disconnect();
 ```
 
@@ -149,7 +149,7 @@ const client = new SafeguardClient('safeguard.sample.corp', {
 });
 
 await client.connect();
-const status = await client.get(Service.NOTIFICATION, 'v4/Status');
+const status = await client.get(Service.NOTIFICATION, 'Status');
 console.log(status);
 ```
 
@@ -163,34 +163,34 @@ const client = new SafeguardClient('safeguard.sample.corp', {
 });
 
 await client.connect();
-const me = await client.get(Service.CORE, 'v4/Me');
+const me = await client.get(Service.CORE, 'Me');
 ```
 
 ## Calling the API
 
-The client provides typed HTTP methods:
+The client provides typed HTTP methods. Pass relative paths only — the SDK prepends the configured API version automatically (`v4` by default):
 
 ```typescript
 // GET
-const users = await client.get(Service.CORE, 'v4/Users');
+const users = await client.get(Service.CORE, 'Users');
 
 // GET with query parameters
-const filtered = await client.get(Service.CORE, 'v4/Users', {
+const filtered = await client.get(Service.CORE, 'Users', {
   query: { filter: "Name eq 'Admin'", fields: 'Id,Name' },
 });
 
 // POST (create)
-const newUser = await client.post(Service.CORE, 'v4/Users', {
+const newUser = await client.post(Service.CORE, 'Users', {
   json: { Name: 'newuser', PrimaryAuthenticationProvider: { Id: -1 } },
 });
 
 // PUT (update)
-await client.put(Service.CORE, `v4/Users/${newUser.Id}/Password`, {
+await client.put(Service.CORE, `Users/${newUser.Id}/Password`, {
   json: 'NewPassword123',
 });
 
 // DELETE
-await client.delete(Service.CORE, `v4/Users/${newUser.Id}`);
+await client.delete(Service.CORE, `Users/${newUser.Id}`);
 ```
 
 ### Services

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oneidentity/safeguard",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oneidentity/safeguard",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@microsoft/signalr": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneidentity/safeguard",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "One Identity Safeguard JavaScript/TypeScript SDK",
   "type": "module",
   "exports": {

--- a/samples/Browser/pkce-login/main.ts
+++ b/samples/Browser/pkce-login/main.ts
@@ -31,6 +31,6 @@ document.getElementById('login')?.addEventListener('click', async () => {
 
   await client.connect();
 
-  const me = await client.get(Service.CORE, 'v4/Me');
+  const me = await client.get(Service.CORE, 'Me');
   document.getElementById('output')!.textContent = JSON.stringify(me, null, 2);
 });

--- a/samples/node/anonymous-status.ts
+++ b/samples/node/anonymous-status.ts
@@ -16,7 +16,7 @@ async function main() {
 
   await client.connect();
 
-  const status = await client.get(Service.NOTIFICATION, 'v4/Status');
+  const status = await client.get(Service.NOTIFICATION, 'Status');
   console.log('Appliance status:', JSON.stringify(status, null, 2));
 
   await client.disconnect();

--- a/samples/node/certificate-auth.ts
+++ b/samples/node/certificate-auth.ts
@@ -19,7 +19,7 @@ async function main() {
   await client.connect();
   console.log('Connected via certificate!');
 
-  const me = await client.get<{ DisplayName: string }>(Service.CORE, 'v4/Me');
+  const me = await client.get<{ DisplayName: string }>(Service.CORE, 'Me');
   console.log('Authenticated as:', me.DisplayName);
 
   await client.disconnect();

--- a/samples/node/password-auth.ts
+++ b/samples/node/password-auth.ts
@@ -21,7 +21,7 @@ async function main() {
   await client.connect();
   console.log('Connected!');
 
-  const me = await client.get<{ DisplayName: string }>(Service.CORE, 'v4/Me');
+  const me = await client.get<{ DisplayName: string }>(Service.CORE, 'Me');
   console.log('Current user:', me.DisplayName);
 
   const remaining = client.getAccessTokenLifetimeRemaining();

--- a/src/a2a/index.ts
+++ b/src/a2a/index.ts
@@ -16,6 +16,8 @@ export interface A2AClientOptions {
   ca?: string | Buffer;
   /** Whether to verify TLS. Default: true. */
   verify?: boolean;
+  /** API version string (default: 'v4'). */
+  apiVersion?: string;
 }
 
 /**
@@ -29,6 +31,7 @@ export class A2AClient {
   readonly #auth: CertificateAuth;
   readonly #ca: string | Buffer | undefined;
   readonly #verify: boolean;
+  readonly #apiVersion: string;
   #httpClient: HttpClient | undefined;
 
   constructor(host: string, options: A2AClientOptions) {
@@ -38,6 +41,7 @@ export class A2AClient {
     this.#auth = options.auth;
     this.#ca = options.ca;
     this.#verify = options.verify !== false;
+    this.#apiVersion = options.apiVersion ?? 'v4';
   }
 
   /** The appliance hostname. */
@@ -73,7 +77,7 @@ export class A2AClient {
    * @param apiKey - The API key for the retrievable account
    */
   async retrievePassword(apiKey: string): Promise<SecretValue> {
-    const body = await this.#a2aRequest(apiKey, 'Credentials', 'Password');
+    const body = await this.#a2aRequest(apiKey, 'GET', 'Credentials', { type: 'Password' });
     return new SecretValue(body);
   }
 
@@ -84,7 +88,10 @@ export class A2AClient {
    */
   async retrievePrivateKey(apiKey: string, format?: SshKeyFormat): Promise<SecretValue> {
     const keyType = format ?? SshKeyFormat.OpenSsh;
-    const body = await this.#a2aRequest(apiKey, 'Credentials', `SshKey?keyFormat=${keyType}`);
+    const body = await this.#a2aRequest(apiKey, 'GET', 'Credentials', {
+      type: 'SshKey',
+      keyFormat: keyType,
+    });
     return new SecretValue(body);
   }
 
@@ -93,7 +100,7 @@ export class A2AClient {
    * @param apiKey - The API key for the retrievable account
    */
   async retrieveApiKeySecret(apiKey: string): Promise<SecretValue> {
-    const body = await this.#a2aRequest(apiKey, 'Credentials', 'ApiKey');
+    const body = await this.#a2aRequest(apiKey, 'GET', 'Credentials', { type: 'ApiKey' });
     return new SecretValue(body);
   }
 
@@ -103,7 +110,7 @@ export class A2AClient {
   async getRetrievableAccounts(): Promise<RetrievableAccount[]> {
     this.#ensureHttpClient();
     const response = await this.#httpClient!.request({
-      url: `https://${this.#host}/service/a2a/v4/A2ARegistrations`,
+      url: `https://${this.#host}/service/a2a/${this.#apiVersion}/A2ARegistrations`,
       method: 'GET',
       headers: {
         Accept: 'application/json',
@@ -125,7 +132,7 @@ export class A2AClient {
   async setPassword(apiKey: string, password: string): Promise<void> {
     this.#ensureHttpClient();
     const response = await this.#httpClient!.request({
-      url: `https://${this.#host}/service/a2a/v4/Credentials/Password`,
+      url: `https://${this.#host}/service/a2a/${this.#apiVersion}/Credentials?type=Password`,
       method: 'PUT',
       headers: {
         Authorization: `A2A ${apiKey}`,
@@ -159,7 +166,7 @@ export class A2AClient {
     if (passphrase) payload['Passphrase'] = passphrase;
 
     const response = await this.#httpClient!.request({
-      url: `https://${this.#host}/service/a2a/v4/Credentials/SshKey`,
+      url: `https://${this.#host}/service/a2a/${this.#apiVersion}/Credentials?type=SshKey`,
       method: 'PUT',
       headers: {
         Authorization: `A2A ${apiKey}`,
@@ -185,7 +192,7 @@ export class A2AClient {
   ): Promise<BrokeredAccessResponse> {
     this.#ensureHttpClient();
     const response = await this.#httpClient!.request({
-      url: `https://${this.#host}/service/a2a/v4/AccessRequests`,
+      url: `https://${this.#host}/service/a2a/${this.#apiVersion}/AccessRequests`,
       method: 'POST',
       headers: {
         Authorization: `A2A ${apiKey}`,
@@ -204,12 +211,22 @@ export class A2AClient {
 
   // ─── Private helpers ────────────────────────────────────────────────
 
-  async #a2aRequest(apiKey: string, ...pathSegments: string[]): Promise<string> {
+  async #a2aRequest(
+    apiKey: string,
+    method: string,
+    endpoint: string,
+    queryParams?: Record<string, string>,
+  ): Promise<string> {
     this.#ensureHttpClient();
-    const path = pathSegments.join('/');
+    let url = `https://${this.#host}/service/a2a/${this.#apiVersion}/${endpoint}`;
+    if (queryParams) {
+      const params = new URLSearchParams(queryParams);
+      url += `?${params.toString()}`;
+    }
+
     const response = await this.#httpClient!.request({
-      url: `https://${this.#host}/service/a2a/v4/${path}`,
-      method: 'GET',
+      url,
+      method,
       headers: {
         Authorization: `A2A ${apiKey}`,
         Accept: 'application/json',

--- a/src/client.ts
+++ b/src/client.ts
@@ -169,7 +169,7 @@ export class SafeguardClient {
       await this.#ensureValidToken();
     }
 
-    const url = buildRequestUrl(this.#host, service, relativeUrl, options?.query);
+    const url = buildRequestUrl(this.#host, service, relativeUrl, options?.query, this.#apiVersion);
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this.#tokenSet!.accessToken.expose()}`,
       Accept: 'application/json',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,20 +44,20 @@ export function validateHost(host: string): string {
  *
  * @example
  * buildServiceUrl('appliance.example.com', Service.CORE)
- * // => 'https://appliance.example.com/service/core'
+ * // => 'https://appliance.example.com/service/core/v4'
  */
-export function buildServiceUrl(host: string, service: Service): string {
+export function buildServiceUrl(host: string, service: Service, apiVersion: string = 'v4'): string {
   if (service === Service.RSTS) {
     return `https://${host}/RSTS`;
   }
-  return `https://${host}/service/${service}`;
+  return `https://${host}/service/${service}/${apiVersion}`;
 }
 
 /**
  * Builds a full API URL including path and optional query parameters.
  *
  * @example
- * buildRequestUrl('appliance.example.com', Service.CORE, 'v4/Users', { filter: 'Name eq "admin"' })
+ * buildRequestUrl('appliance.example.com', Service.CORE, 'Users', { filter: 'Name eq "admin"' })
  * // => 'https://appliance.example.com/service/core/v4/Users?filter=Name+eq+%22admin%22'
  */
 export function buildRequestUrl(
@@ -65,8 +65,9 @@ export function buildRequestUrl(
   service: Service,
   relativeUrl: string,
   query?: Record<string, string | number | boolean>,
+  apiVersion: string = 'v4',
 ): string {
-  const base = buildServiceUrl(host, service);
+  const base = buildServiceUrl(host, service, apiVersion);
   const path = relativeUrl.startsWith('/') ? relativeUrl.slice(1) : relativeUrl;
   const url = new URL(`${base}/${path}`);
 

--- a/tests/integration/auth.test.ts
+++ b/tests/integration/auth.test.ts
@@ -41,7 +41,7 @@ describe('Authentication', () => {
       }
       const me = await adminClient.get<{ Id: number; Name: string }>(
         Service.CORE,
-        'v4/Me',
+        'Me',
       );
       expect(me.Id).toBeDefined();
       expect(me.Name).toBeTruthy();

--- a/tests/integration/concurrent.test.ts
+++ b/tests/integration/concurrent.test.ts
@@ -25,7 +25,7 @@ describe('Concurrent Requests', () => {
 
   it('handles 5 parallel GET requests', async () => {
     const requests = Array.from({ length: 5 }, () =>
-      client.get<{ Id: number; Name: string }>(Service.CORE, 'v4/Me'),
+      client.get<{ Id: number; Name: string }>(Service.CORE, 'Me'),
     );
     const results = await Promise.all(requests);
     expect(results).toHaveLength(5);
@@ -37,11 +37,11 @@ describe('Concurrent Requests', () => {
 
   it('handles mixed endpoint parallel requests', async () => {
     const [me, users, status, providers, settings] = await Promise.all([
-      client.get<{ Id: number }>(Service.CORE, 'v4/Me'),
-      client.get<Array<{ Id: number }>>(Service.CORE, 'v4/Users'),
-      client.get<{ ApplianceCurrentState: string }>(Service.NOTIFICATION, 'v4/Status'),
-      client.get<Array<{ Id: number }>>(Service.CORE, 'v4/AuthenticationProviders'),
-      client.get<Array<{ Name: string }>>(Service.CORE, 'v4/Settings'),
+      client.get<{ Id: number }>(Service.CORE, 'Me'),
+      client.get<Array<{ Id: number }>>(Service.CORE, 'Users'),
+      client.get<{ ApplianceCurrentState: string }>(Service.NOTIFICATION, 'Status'),
+      client.get<Array<{ Id: number }>>(Service.CORE, 'AuthenticationProviders'),
+      client.get<Array<{ Name: string }>>(Service.CORE, 'Settings'),
     ]);
     expect(me.Id).toBeDefined();
     expect(users.length).toBeGreaterThan(0);
@@ -52,7 +52,7 @@ describe('Concurrent Requests', () => {
 
   it('handles 10 rapid sequential requests without error', async () => {
     for (let i = 0; i < 10; i++) {
-      const me = await client.get<{ Id: number }>(Service.CORE, 'v4/Me');
+      const me = await client.get<{ Id: number }>(Service.CORE, 'Me');
       expect(me.Id).toBeDefined();
     }
   });

--- a/tests/integration/fixtures.ts
+++ b/tests/integration/fixtures.ts
@@ -61,7 +61,7 @@ export async function ensureResourceOwnerGrant(client: SafeguardClient): Promise
   // Just do a quick health check to confirm the appliance is responsive.
   const response = await client.get<{ ApplianceCurrentState?: string }>(
     Service.NOTIFICATION,
-    'v4/Status',
+    'Status',
   );
   if (response.ApplianceCurrentState !== 'Online') {
     throw new Error(

--- a/tests/integration/invoke.test.ts
+++ b/tests/integration/invoke.test.ts
@@ -33,7 +33,7 @@ describe('API Invocation', () => {
     it('reads current user (Me)', async () => {
       const me = await client.get<{ Id: number; Name: string; AdminRoles: string[] }>(
         Service.CORE,
-        'v4/Me',
+        'Me',
       );
       // Bootstrap admin has Id -2
       expect(me.Id).toBeDefined();
@@ -44,7 +44,7 @@ describe('API Invocation', () => {
     it('lists users with query parameters', async () => {
       const users = await client.get<Array<{ Id: number; Name: string }>>(
         Service.CORE,
-        'v4/Users',
+        'Users',
         { query: { filter: `Name eq '${env.username.toLowerCase()}'` } },
       );
       expect(users.length).toBeGreaterThanOrEqual(1);
@@ -53,7 +53,7 @@ describe('API Invocation', () => {
     it('reads appliance status', async () => {
       const status = await client.get<{ ApplianceCurrentState: string }>(
         Service.NOTIFICATION,
-        'v4/Status',
+        'Status',
       );
       expect(status.ApplianceCurrentState).toBe('Online');
     });
@@ -61,7 +61,7 @@ describe('API Invocation', () => {
     it('lists authentication providers', async () => {
       const providers = await client.get<Array<{ Id: number; Name: string }>>(
         Service.CORE,
-        'v4/AuthenticationProviders',
+        'AuthenticationProviders',
       );
       expect(providers.length).toBeGreaterThanOrEqual(1);
       const local = providers.find((p) => p.Name === 'Local');
@@ -71,7 +71,7 @@ describe('API Invocation', () => {
     it('reads settings', async () => {
       const settings = await client.get<Array<{ Name: string; Value: string }>>(
         Service.CORE,
-        'v4/Settings',
+        'Settings',
       );
       expect(settings.length).toBeGreaterThan(0);
       expect(settings[0]!.Name).toBeTruthy();
@@ -85,7 +85,7 @@ describe('API Invocation', () => {
     it('creates a user (POST)', async () => {
       const user = await client.post<{ Id: number; Name: string }>(
         Service.CORE,
-        'v4/Users',
+        'Users',
         {
           json: {
             Name: userName,
@@ -100,7 +100,7 @@ describe('API Invocation', () => {
       cleanup.register(async () => {
         if (userId) {
           try {
-            await client.delete(Service.CORE, `v4/Users/${userId}`);
+            await client.delete(Service.CORE, `Users/${userId}`);
           } catch { /* best effort */ }
         }
       });
@@ -110,7 +110,7 @@ describe('API Invocation', () => {
       expect(userId).toBeDefined();
       const user = await client.get<{ Id: number; Name: string }>(
         Service.CORE,
-        `v4/Users/${userId}`,
+        `Users/${userId}`,
       );
       expect(user.Id).toBe(userId);
       expect(user.Name).toBe(userName);
@@ -120,7 +120,7 @@ describe('API Invocation', () => {
       expect(userId).toBeDefined();
       const updated = await client.put<{ Id: number; Description: string }>(
         Service.CORE,
-        `v4/Users/${userId}`,
+        `Users/${userId}`,
         {
           json: {
             Id: userId,
@@ -135,10 +135,10 @@ describe('API Invocation', () => {
 
     it('deletes the user (DELETE)', async () => {
       expect(userId).toBeDefined();
-      await client.delete(Service.CORE, `v4/Users/${userId}`);
+      await client.delete(Service.CORE, `Users/${userId}`);
       // Verify it's gone
       await expect(
-        client.get(Service.CORE, `v4/Users/${userId}`),
+        client.get(Service.CORE, `Users/${userId}`),
       ).rejects.toThrow(ApiError);
       userId = undefined; // prevent double-delete in cleanup
     });
@@ -150,7 +150,7 @@ describe('API Invocation', () => {
         data: { Id: number };
         status: number;
         headers: Record<string, string>;
-      }>(Service.CORE, HttpMethod.GET, 'v4/Me', { fullResponse: true });
+      }>(Service.CORE, HttpMethod.GET, 'Me', { fullResponse: true });
       expect(result.status).toBe(200);
       expect(result.headers).toBeDefined();
       expect(result.data).toBeDefined();
@@ -160,13 +160,13 @@ describe('API Invocation', () => {
   describe('error handling', () => {
     it('throws ApiError for 404', async () => {
       await expect(
-        client.get(Service.CORE, 'v4/Users/999999999'),
+        client.get(Service.CORE, 'Users/999999999'),
       ).rejects.toThrow(ApiError);
     });
 
     it('error has status property', async () => {
       try {
-        await client.get(Service.CORE, 'v4/Users/999999999');
+        await client.get(Service.CORE, 'Users/999999999');
         expect.fail('Expected ApiError');
       } catch (err) {
         expect(err).toBeInstanceOf(ApiError);

--- a/tests/integration/management.test.ts
+++ b/tests/integration/management.test.ts
@@ -32,7 +32,7 @@ describe('User Management', () => {
     it('creates a local user', async () => {
       const user = await client.post<{ Id: number; Name: string }>(
         Service.CORE,
-        'v4/Users',
+        'Users',
         {
           json: {
             Name: userName,
@@ -47,7 +47,7 @@ describe('User Management', () => {
       cleanup.register(async () => {
         if (userId) {
           try {
-            await client.delete(Service.CORE, `v4/Users/${userId}`);
+            await client.delete(Service.CORE, `Users/${userId}`);
           } catch { /* best effort */ }
         }
       });
@@ -57,7 +57,7 @@ describe('User Management', () => {
       expect(userId).toBeDefined();
       const users = await client.get<Array<{ Id: number; Name: string }>>(
         Service.CORE,
-        'v4/Users',
+        'Users',
         { query: { filter: `Name eq '${userName}'` } },
       );
       expect(users.length).toBe(1);
@@ -68,7 +68,7 @@ describe('User Management', () => {
       expect(userId).toBeDefined();
       const updated = await client.put<{ Id: number; Description: string }>(
         Service.CORE,
-        `v4/Users/${userId}`,
+        `Users/${userId}`,
         {
           json: {
             Id: userId,
@@ -83,11 +83,11 @@ describe('User Management', () => {
 
     it('deletes the user', async () => {
       expect(userId).toBeDefined();
-      await client.delete(Service.CORE, `v4/Users/${userId}`);
+      await client.delete(Service.CORE, `Users/${userId}`);
       // Verify gone
       const users = await client.get<Array<{ Id: number }>>(
         Service.CORE,
-        'v4/Users',
+        'Users',
         { query: { filter: `Name eq '${userName}'` } },
       );
       expect(users.length).toBe(0);
@@ -104,7 +104,7 @@ describe('User Management', () => {
         const name = uniqueName(`Batch${i}`);
         const user = await client.post<{ Id: number; Name: string }>(
           Service.CORE,
-          'v4/Users',
+          'Users',
           {
             json: {
               Name: name,
@@ -122,7 +122,7 @@ describe('User Management', () => {
     it('lists all created users', async () => {
       const allUsers = await client.get<Array<{ Id: number; Name: string }>>(
         Service.CORE,
-        'v4/Users',
+        'Users',
       );
       for (const id of userIds) {
         expect(allUsers.find((u) => u.Id === id)).toBeDefined();
@@ -131,13 +131,13 @@ describe('User Management', () => {
 
     it('cleans up batch users', async () => {
       for (const id of userIds) {
-        await client.delete(Service.CORE, `v4/Users/${id}`);
+        await client.delete(Service.CORE, `Users/${id}`);
       }
       // Verify all gone
       for (const name of userNames) {
         const remaining = await client.get<Array<{ Id: number }>>(
           Service.CORE,
-          'v4/Users',
+          'Users',
           { query: { filter: `Name eq '${name}'` } },
         );
         expect(remaining.length).toBe(0);

--- a/tests/integration/query-params.test.ts
+++ b/tests/integration/query-params.test.ts
@@ -32,11 +32,11 @@ describe('Query Parameters', () => {
   it('supports limit to restrict results', async () => {
     const allUsers = await client.get<Array<{ Id: number }>>(
       Service.CORE,
-      'v4/Users',
+      'Users',
     );
     const limited = await client.get<Array<{ Id: number }>>(
       Service.CORE,
-      'v4/Users',
+      'Users',
       { query: { limit: 2 } },
     );
     expect(limited.length).toBe(2);
@@ -46,12 +46,12 @@ describe('Query Parameters', () => {
   it('supports page + limit for pagination', async () => {
     const page0 = await client.get<Array<{ Id: number; Name: string }>>(
       Service.CORE,
-      'v4/Users',
+      'Users',
       { query: { page: 0, limit: 2 } },
     );
     const page1 = await client.get<Array<{ Id: number; Name: string }>>(
       Service.CORE,
-      'v4/Users',
+      'Users',
       { query: { page: 1, limit: 2 } },
     );
     expect(page0.length).toBe(2);
@@ -67,7 +67,7 @@ describe('Query Parameters', () => {
   it('supports orderby ascending', async () => {
     const ascending = await client.get<Array<{ Name: string }>>(
       Service.CORE,
-      'v4/Users',
+      'Users',
       { query: { orderby: 'Name' } },
     );
     // Verify sorted ascending (case-insensitive)
@@ -80,7 +80,7 @@ describe('Query Parameters', () => {
   it('supports orderby descending with minus prefix', async () => {
     const descending = await client.get<Array<{ Name: string }>>(
       Service.CORE,
-      'v4/Users',
+      'Users',
       { query: { orderby: '-Name' } },
     );
     // Verify sorted descending (case-insensitive)
@@ -93,7 +93,7 @@ describe('Query Parameters', () => {
   it('supports fields to select specific properties', async () => {
     const sparse = await client.get<Array<Record<string, unknown>>>(
       Service.CORE,
-      'v4/Users',
+      'Users',
       { query: { limit: 1, fields: 'Id,Name' } },
     );
     const keys = Object.keys(sparse[0]!);
@@ -106,7 +106,7 @@ describe('Query Parameters', () => {
   it('combines limit + orderby', async () => {
     const topDesc = await client.get<Array<{ Name: string }>>(
       Service.CORE,
-      'v4/Users',
+      'Users',
       { query: { limit: 2, orderby: '-Name' } },
     );
     expect(topDesc.length).toBe(2);

--- a/tests/integration/settings.test.ts
+++ b/tests/integration/settings.test.ts
@@ -34,7 +34,7 @@ describe('Settings Read/Write', () => {
   });
 
   it('reads all settings', async () => {
-    const settings = await client.get<Setting[]>(Service.CORE, 'v4/Settings');
+    const settings = await client.get<Setting[]>(Service.CORE, 'Settings');
     expect(settings.length).toBeGreaterThan(0);
     for (const s of settings) {
       expect(s.Name).toBeTruthy();
@@ -45,7 +45,7 @@ describe('Settings Read/Write', () => {
   it('reads a specific setting by name', async () => {
     const settings = await client.get<Setting[]>(
       Service.CORE,
-      'v4/Settings',
+      'Settings',
       { query: { filter: "Name eq 'Inform User of Bad Password'" } },
     );
     expect(settings.length).toBe(1);
@@ -58,7 +58,7 @@ describe('Settings Read/Write', () => {
     // Read current value
     const settings = await client.get<Setting[]>(
       Service.CORE,
-      'v4/Settings',
+      'Settings',
       { query: { filter: `Name eq '${settingName}'` } },
     );
     const original = settings[0]!;
@@ -66,7 +66,7 @@ describe('Settings Read/Write', () => {
     // PUT targets the specific setting by name in the path
     const updated = await client.put<Setting>(
       Service.CORE,
-      `v4/Settings/${encodeURIComponent(settingName)}`,
+      `Settings/${encodeURIComponent(settingName)}`,
       {
         json: {
           Name: original.Name,
@@ -79,7 +79,7 @@ describe('Settings Read/Write', () => {
   });
 
   it('settings categories include Authentication', async () => {
-    const settings = await client.get<Setting[]>(Service.CORE, 'v4/Settings');
+    const settings = await client.get<Setting[]>(Service.CORE, 'Settings');
     const categories = [...new Set(settings.map((s) => s.Category))];
     expect(categories).toContain('Authentication');
   });

--- a/tests/integration/timeout.test.ts
+++ b/tests/integration/timeout.test.ts
@@ -25,14 +25,14 @@ describe('Request Timeout', () => {
 
   it('throws on impossibly short timeout (1ms)', async () => {
     await expect(
-      client.get(Service.CORE, 'v4/Me', { timeout: 1 }),
+      client.get(Service.CORE, 'Me', { timeout: 1 }),
     ).rejects.toThrow();
   });
 
   it('succeeds with generous timeout', async () => {
     const me = await client.get<{ Id: number }>(
       Service.CORE,
-      'v4/Me',
+      'Me',
       { timeout: 30_000 },
     );
     expect(me.Id).toBeDefined();
@@ -41,11 +41,11 @@ describe('Request Timeout', () => {
   it('per-request timeout does not affect subsequent requests', async () => {
     // First request with very short timeout should fail
     await expect(
-      client.get(Service.CORE, 'v4/Me', { timeout: 1 }),
+      client.get(Service.CORE, 'Me', { timeout: 1 }),
     ).rejects.toThrow();
 
     // Subsequent request with default timeout should succeed
-    const me = await client.get<{ Id: number }>(Service.CORE, 'v4/Me');
+    const me = await client.get<{ Id: number }>(Service.CORE, 'Me');
     expect(me.Id).toBeDefined();
   });
 });

--- a/tests/integration/token-lifecycle.test.ts
+++ b/tests/integration/token-lifecycle.test.ts
@@ -49,14 +49,14 @@ describe('Token Lifecycle', () => {
 
     // After disconnect, API calls should fail
     await expect(
-      client.get(Service.CORE, 'v4/Me'),
+      client.get(Service.CORE, 'Me'),
     ).rejects.toThrow(ConfigurationError);
 
     // Reconnect with a fresh client
     const client2 = await createAdminClient(env);
     clients.push(client2);
     expect(client2.isConnected).toBe(true);
-    const me = await client2.get<{ Id: number }>(Service.CORE, 'v4/Me');
+    const me = await client2.get<{ Id: number }>(Service.CORE, 'Me');
     expect(me.Id).toBeDefined();
   });
 });

--- a/tests/unit/a2a.test.ts
+++ b/tests/unit/a2a.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { A2AClient, BrokeredAccessRequestType, SshKeyFormat } from '../../src/a2a/index.js';
+import { CertificateAuth } from '../../src/auth/certificate.js';
+import type { HttpClient, HttpResponse } from '../../src/http/types.js';
+
+function createAuth(): CertificateAuth {
+  return new CertificateAuth({ cert: 'cert-pem', key: 'key-pem' });
+}
+
+function createMockHttpClient(responseBody = 'secret', status = 200): HttpClient {
+  return {
+    request: vi.fn(async (): Promise<HttpResponse> => ({
+      status,
+      headers: { 'content-type': 'application/json' },
+      body: responseBody,
+    })),
+  };
+}
+
+describe('A2AClient', () => {
+  let client: A2AClient;
+  let httpClient: HttpClient;
+
+  beforeEach(() => {
+    httpClient = createMockHttpClient();
+    client = new A2AClient('appliance.example.com', { auth: createAuth() });
+    client.setHttpClient(httpClient);
+  });
+
+  it('retrieves passwords via query parameters', async () => {
+    const secret = await client.retrievePassword('api-key');
+    const call = (httpClient.request as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+
+    expect(secret.expose()).toBe('secret');
+    expect(call.url).toBe(
+      'https://appliance.example.com/service/a2a/v4/Credentials?type=Password',
+    );
+    expect(call.method).toBe('GET');
+    expect(call.headers.Authorization).toBe('A2A api-key');
+  });
+
+  it('retrieves SSH keys via query parameters', async () => {
+    await client.retrievePrivateKey('api-key');
+    const call = (httpClient.request as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+
+    expect(call.url).toBe(
+      'https://appliance.example.com/service/a2a/v4/Credentials?type=SshKey&keyFormat=OpenSsh',
+    );
+  });
+
+  it('retrieves API key secrets via query parameters', async () => {
+    await client.retrieveApiKeySecret('api-key');
+    const call = (httpClient.request as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+
+    expect(call.url).toBe(
+      'https://appliance.example.com/service/a2a/v4/Credentials?type=ApiKey',
+    );
+  });
+
+  it('uses the configured api version for discovery', async () => {
+    const versionedClient = new A2AClient('appliance.example.com', {
+      auth: createAuth(),
+      apiVersion: 'v3',
+    });
+    const versionedHttpClient = createMockHttpClient(
+      JSON.stringify([{ AccountId: 1, ApiKey: 'api-key' }]),
+    );
+    versionedClient.setHttpClient(versionedHttpClient);
+
+    await versionedClient.getRetrievableAccounts();
+    const call = (versionedHttpClient.request as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+
+    expect(call.url).toBe('https://appliance.example.com/service/a2a/v3/A2ARegistrations');
+    expect(call.method).toBe('GET');
+  });
+
+  it('sets passwords with the credential type in the query string', async () => {
+    const updateClient = createMockHttpClient('', 204);
+    client.setHttpClient(updateClient);
+
+    await client.setPassword('api-key', 'NewPassword123');
+    const call = (updateClient.request as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+
+    expect(call.url).toBe(
+      'https://appliance.example.com/service/a2a/v4/Credentials?type=Password',
+    );
+    expect(call.method).toBe('PUT');
+    expect(call.body).toBe('"NewPassword123"');
+  });
+
+  it('sets private keys with the credential type in the query string', async () => {
+    const updateClient = createMockHttpClient('', 204);
+    client.setHttpClient(updateClient);
+
+    await client.setPrivateKey('api-key', 'PRIVATE KEY', 'passphrase', SshKeyFormat.Putty);
+    const call = (updateClient.request as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+
+    expect(call.url).toBe('https://appliance.example.com/service/a2a/v4/Credentials?type=SshKey');
+    expect(call.method).toBe('PUT');
+    expect(JSON.parse(call.body as string)).toEqual({
+      PrivateKey: 'PRIVATE KEY',
+      KeyFormat: 'Putty',
+      Passphrase: 'passphrase',
+    });
+  });
+
+  it('uses the configured api version for brokered access requests', async () => {
+    const versionedClient = new A2AClient('appliance.example.com', {
+      auth: createAuth(),
+      apiVersion: 'v3',
+    });
+    const brokerHttpClient = createMockHttpClient(JSON.stringify({ RequestId: 'req-1' }), 201);
+    versionedClient.setHttpClient(brokerHttpClient);
+
+    await versionedClient.brokerAccessRequest('api-key', {
+      AccessType: BrokeredAccessRequestType.Password,
+      AccountId: 1,
+    });
+    const call = (brokerHttpClient.request as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+
+    expect(call.url).toBe('https://appliance.example.com/service/a2a/v3/AccessRequests');
+    expect(call.method).toBe('POST');
+  });
+});

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -101,20 +101,33 @@ describe('SafeguardClient', () => {
       const disconnected = new SafeguardClient('h', { auth: createMockAuth() });
       disconnected.setHttpClient(createMockHttpClient());
       await expect(
-        disconnected.invoke(Service.CORE, HttpMethod.GET, 'v4/Me'),
+        disconnected.invoke(Service.CORE, HttpMethod.GET, 'Me'),
       ).rejects.toThrow('not connected');
     });
 
     it('sends GET with Authorization header', async () => {
-      await client.get(Service.CORE, 'v4/Me');
+      await client.get(Service.CORE, 'Me');
       const call = (httpClient.request as ReturnType<typeof vi.fn>).mock.calls[0]![0];
       expect(call.url).toBe('https://appliance.example.com/service/core/v4/Me');
       expect(call.method).toBe('GET');
       expect(call.headers.Authorization).toMatch(/^Bearer /);
     });
 
+    it('uses the configured api version in request URLs', async () => {
+      const versionedClient = new SafeguardClient('appliance.example.com', {
+        auth: createMockAuth(),
+        apiVersion: 'v3',
+      });
+      versionedClient.setHttpClient(httpClient);
+      await versionedClient.connect();
+
+      await versionedClient.get(Service.CORE, 'Me');
+      const call = (httpClient.request as ReturnType<typeof vi.fn>).mock.calls.at(-1)![0];
+      expect(call.url).toBe('https://appliance.example.com/service/core/v3/Me');
+    });
+
     it('sends POST with JSON body', async () => {
-      await client.post(Service.CORE, 'v4/Users', { json: { Name: 'New' } });
+      await client.post(Service.CORE, 'Users', { json: { Name: 'New' } });
       const call = (httpClient.request as ReturnType<typeof vi.fn>).mock.calls[0]![0];
       expect(call.method).toBe('POST');
       expect(call.headers['Content-Type']).toBe('application/json');
@@ -122,18 +135,18 @@ describe('SafeguardClient', () => {
     });
 
     it('appends query parameters', async () => {
-      await client.get(Service.CORE, 'v4/Users', { query: { filter: 'Name eq "x"' } });
+      await client.get(Service.CORE, 'Users', { query: { filter: 'Name eq "x"' } });
       const call = (httpClient.request as ReturnType<typeof vi.fn>).mock.calls[0]![0];
       expect(call.url).toContain('filter=Name');
     });
 
     it('returns parsed JSON body by default', async () => {
-      const result = await client.get<{ Id: number }>(Service.CORE, 'v4/Me');
+      const result = await client.get<{ Id: number }>(Service.CORE, 'Me');
       expect(result).toEqual({ Id: 1, Name: 'Admin' });
     });
 
     it('returns full response when fullResponse: true', async () => {
-      const result = await client.invoke(Service.CORE, HttpMethod.GET, 'v4/Me', {
+      const result = await client.invoke(Service.CORE, HttpMethod.GET, 'Me', {
         fullResponse: true,
       });
       expect(result).toHaveProperty('data');
@@ -149,7 +162,7 @@ describe('SafeguardClient', () => {
       const c = new SafeguardClient('h', { auth: createMockAuth() });
       c.setHttpClient(errorClient);
       await c.connect();
-      await expect(c.get(Service.CORE, 'v4/Bogus')).rejects.toThrow();
+      await expect(c.get(Service.CORE, 'Bogus')).rejects.toThrow();
     });
   });
 
@@ -201,7 +214,7 @@ describe('SafeguardClient', () => {
       const client = new SafeguardClient('h', { auth, autoRefresh: true });
       client.setHttpClient(createMockHttpClient());
       await client.connect();
-      await client.get(Service.CORE, 'v4/Me');
+      await client.get(Service.CORE, 'Me');
 
       expect(auth.authenticate).toHaveBeenCalledTimes(2);
     });
@@ -217,7 +230,7 @@ describe('SafeguardClient', () => {
       const client = new SafeguardClient('h', { auth, autoRefresh: false });
       client.setHttpClient(createMockHttpClient());
       await client.connect();
-      await client.get(Service.CORE, 'v4/Me');
+      await client.get(Service.CORE, 'Me');
 
       expect(auth.authenticate).toHaveBeenCalledTimes(1);
     });

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -13,13 +13,13 @@ import {
 describe('buildServiceUrl', () => {
   it('builds core service URL', () => {
     expect(buildServiceUrl('sg.example.com', Service.CORE)).toBe(
-      'https://sg.example.com/service/core',
+      'https://sg.example.com/service/core/v4',
     );
   });
 
   it('builds appliance service URL', () => {
     expect(buildServiceUrl('sg.example.com', Service.APPLIANCE)).toBe(
-      'https://sg.example.com/service/appliance',
+      'https://sg.example.com/service/appliance/v4',
     );
   });
 
@@ -31,24 +31,30 @@ describe('buildServiceUrl', () => {
 
   it('builds notification service URL', () => {
     expect(buildServiceUrl('sg.example.com', Service.NOTIFICATION)).toBe(
-      'https://sg.example.com/service/notification',
+      'https://sg.example.com/service/notification/v4',
+    );
+  });
+
+  it('builds service URL with custom api version', () => {
+    expect(buildServiceUrl('sg.example.com', Service.CORE, 'v3')).toBe(
+      'https://sg.example.com/service/core/v3',
     );
   });
 });
 
 describe('buildRequestUrl', () => {
   it('builds full URL with relative path', () => {
-    const url = buildRequestUrl('sg.example.com', Service.CORE, 'v4/Users');
+    const url = buildRequestUrl('sg.example.com', Service.CORE, 'Users');
     expect(url).toBe('https://sg.example.com/service/core/v4/Users');
   });
 
   it('handles leading slash in relative URL', () => {
-    const url = buildRequestUrl('sg.example.com', Service.CORE, '/v4/Users');
+    const url = buildRequestUrl('sg.example.com', Service.CORE, '/Users');
     expect(url).toBe('https://sg.example.com/service/core/v4/Users');
   });
 
   it('includes query parameters', () => {
-    const url = buildRequestUrl('sg.example.com', Service.CORE, 'v4/Users', {
+    const url = buildRequestUrl('sg.example.com', Service.CORE, 'Users', {
       filter: 'Name eq "admin"',
       count: 10,
     });
@@ -58,11 +64,16 @@ describe('buildRequestUrl', () => {
   });
 
   it('handles boolean query parameter', () => {
-    const url = buildRequestUrl('sg.example.com', Service.CORE, 'v4/Users', {
+    const url = buildRequestUrl('sg.example.com', Service.CORE, 'Users', {
       includeDeleted: true,
     });
     const parsed = new URL(url);
     expect(parsed.searchParams.get('includeDeleted')).toBe('true');
+  });
+
+  it('passes through a custom api version', () => {
+    const url = buildRequestUrl('sg.example.com', Service.CORE, 'Users', undefined, 'v3');
+    expect(url).toBe('https://sg.example.com/service/core/v3/Users');
   });
 
   it('works with RSTS service', () => {


### PR DESCRIPTION
## Summary

Fixes two bugs in the SDK:

1. **API version not included in URLs** - `buildServiceUrl`/`buildRequestUrl` now automatically include the configured `apiVersion` (default `v4`). Users no longer need to manually prefix paths with `v4/`.

2. **A2A credential retrieval uses wrong endpoint** - Changed from path-based `Credentials/Password` to query-param-based `Credentials?type=Password` to match the actual SPP API.

## Changes
- `src/utils.ts` - `buildServiceUrl` accepts and includes apiVersion
- `src/client.ts` - passes apiVersion through to URL builder
- `src/a2a/index.ts` - fixed credential URL, added configurable apiVersion
- `package.json` - version bump to 8.0.1
- All tests updated (138 passing)
- README, MIGRATION.md, samples updated

## Breaking Change

Users who were manually prefixing `v4/` in their paths will get double-prefixed URLs. The MIGRATION.md documents this.