### PR TITLE
security: bump safeguard.js to 8.0.2 — re-release after security fix landed post-v8.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oneidentity/safeguard",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oneidentity/safeguard",
-      "version": "8.0.1",
+      "version": "8.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^8.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneidentity/safeguard",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "One Identity Safeguard JavaScript/TypeScript SDK",
   "type": "module",
   "exports": {

--- a/pipeline-templates/global-variables.yml
+++ b/pipeline-templates/global-variables.yml
@@ -1,5 +1,5 @@
 variables:
   - name: semanticVersion
-    value: '8.0.1'
+    value: '8.0.2'
   - name: isTagBuild
     value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}


### PR DESCRIPTION
The `v8.0.1` tag on `main` was published from commit `69062c4` (skills-harmonization) **before** PR #29 landed the targeted security hardening at `91af4a2`. The `package.json` was not bumped after the security merge, so the security fix has no path to npm under the existing version.

Bumping to `8.0.2` so the security hardening (single-flight token refresh, PKCE loopback bind, TLS docs) reaches the registry under a distinct version.

## Changes
- `package.json`: `8.0.1` → `8.0.2`
- `package-lock.json`: regenerated with `npm install --package-lock-only`
- `pipeline-templates/global-variables.yml`: `semanticVersion: 8.0.2`

## Testing
- `npm test`: 142/142 unit tests pass

## Release plan
After merge, push tag `v8.0.2` to trigger the publish pipeline.
